### PR TITLE
Add maintenance system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "de.dergamer09"
-version = "1.0-SNAPSHOT"
+version = "1.0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/java/de/dergamer09/Main.java
+++ b/src/main/java/de/dergamer09/Main.java
@@ -3,9 +3,28 @@ package de.dergamer09;
 import cn.nukkit.plugin.PluginBase;
 import de.dergamer09.commands.DayCommand;
 import de.dergamer09.commands.HealCommand;
+import de.dergamer09.commands.MaintenanceCommand;
 import de.dergamer09.commands.NightCommand;
+import de.dergamer09.listener.MaintenanceListener;
 
 public class Main extends PluginBase {
+
+    private boolean maintenance = false;
+
+    public boolean isMaintenance() {
+        return maintenance;
+    }
+
+    public void setMaintenance(boolean maintenance) {
+        this.maintenance = maintenance;
+        if (maintenance) {
+            this.getServer().getOnlinePlayers().values().forEach(player -> {
+                if (!player.hasPermission("maintenance.bypass")) {
+                    player.kick("Server befindet sich im Wartungsmodus.");
+                }
+            });
+        }
+    }
 
     @Override
     public void onEnable() {
@@ -14,6 +33,9 @@ public class Main extends PluginBase {
         this.getServer().getCommandMap().register("day", new DayCommand());
         this.getServer().getCommandMap().register("night", new NightCommand());
         this.getServer().getCommandMap().register("heal", new HealCommand());
+        this.getServer().getCommandMap().register("maintenance", new MaintenanceCommand(this));
+
+        this.getServer().getPluginManager().registerEvents(new MaintenanceListener(this), this);
     }
 
     @Override

--- a/src/main/java/de/dergamer09/commands/MaintenanceCommand.java
+++ b/src/main/java/de/dergamer09/commands/MaintenanceCommand.java
@@ -1,0 +1,41 @@
+package de.dergamer09.commands;
+
+import cn.nukkit.command.Command;
+import cn.nukkit.command.CommandSender;
+import cn.nukkit.utils.TextFormat;
+import de.dergamer09.Main;
+
+public class MaintenanceCommand extends Command {
+
+    private final Main plugin;
+
+    public MaintenanceCommand(Main plugin) {
+        super("maintenance");
+        this.plugin = plugin;
+        this.setDescription("Schaltet den Wartungsmodus ein oder aus");
+        this.setUsage("/maintenance <on|off>");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off>");
+            return false;
+        }
+
+        String arg = args[0].toLowerCase();
+        boolean state;
+        if ("on".equals(arg)) {
+            state = true;
+        } else if ("off".equals(arg)) {
+            state = false;
+        } else {
+            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off>");
+            return false;
+        }
+
+        plugin.setMaintenance(state);
+        sender.sendMessage(TextFormat.GREEN + "Wartungsmodus " + (state ? "aktiviert" : "deaktiviert") + ".");
+        return true;
+    }
+}

--- a/src/main/java/de/dergamer09/listener/MaintenanceListener.java
+++ b/src/main/java/de/dergamer09/listener/MaintenanceListener.java
@@ -1,0 +1,26 @@
+package de.dergamer09.listener;
+
+import cn.nukkit.event.EventHandler;
+import cn.nukkit.event.Listener;
+import cn.nukkit.event.player.PlayerLoginEvent;
+import cn.nukkit.utils.TextFormat;
+import de.dergamer09.Main;
+
+public class MaintenanceListener implements Listener {
+
+    private final Main plugin;
+
+    public MaintenanceListener(Main plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        if (plugin.isMaintenance()) {
+            if (!event.getPlayer().hasPermission("maintenance.bypass")) {
+                event.setKickMessage(TextFormat.RED + "Server befindet sich im Wartungsmodus.");
+                event.setCancelled(true);
+            }
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Meynonix
-version: 1.0.0
+version: 1.0.1-SNAPSHOT
 main: de.dergamer09.Main
 api: 1.1.0
 author: DerGamer09
@@ -14,3 +14,6 @@ commands:
   heal:
     description: Heilt den Spieler
     usage: /heal
+  maintenance:
+    description: Schaltet den Wartungsmodus ein oder aus
+    usage: /maintenance <on|off>


### PR DESCRIPTION
## Summary
- add maintenance mode command
- kick players in maintenance mode unless they have bypass permission
- register maintenance listener
- update plugin configuration
- bump plugin version to 1.0.1-SNAPSHOT

## Testing
- `./gradlew test` *(fails: unable to download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6861b60036f0832e96b0941a78eaddef