### PR TITLE
Fix Java version mismatch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,3 +24,12 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<JavaCompile> {
+    options.release.set(17)
+}


### PR DESCRIPTION
## Summary
- set Java compatibility to 17 for plugin builds

## Testing
- `gradle test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9dbac24832e99c78841f0ea6276