### PR TITLE
Add German aliases for maintenance command

### DIFF
--- a/src/main/java/de/dergamer09/commands/MaintenanceCommand.java
+++ b/src/main/java/de/dergamer09/commands/MaintenanceCommand.java
@@ -13,24 +13,24 @@ public class MaintenanceCommand extends Command {
         super("maintenance");
         this.plugin = plugin;
         this.setDescription("Schaltet den Wartungsmodus ein oder aus");
-        this.setUsage("/maintenance <on|off>");
+        this.setUsage("/maintenance <on|off|an|aus>");
     }
 
     @Override
     public boolean execute(CommandSender sender, String commandLabel, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off>");
+            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off|an|aus>");
             return false;
         }
 
         String arg = args[0].toLowerCase();
         boolean state;
-        if ("on".equals(arg)) {
+        if ("on".equals(arg) || "an".equals(arg)) {
             state = true;
-        } else if ("off".equals(arg)) {
+        } else if ("off".equals(arg) || "aus".equals(arg)) {
             state = false;
         } else {
-            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off>");
+            sender.sendMessage(TextFormat.RED + "Benutze /maintenance <on|off|an|aus>");
             return false;
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,4 +16,4 @@ commands:
     usage: /heal
   maintenance:
     description: Schaltet den Wartungsmodus ein oder aus
-    usage: /maintenance <on|off>
+    usage: /maintenance <on|off|an|aus>


### PR DESCRIPTION
## Summary
- update maintenance command usage in plugin.yml
- allow using German words `an`/`aus` for the maintenance command

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb2ff07c832e9940d225836e78e2