### PR TITLE
Set API to 1.0.0

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Meynonix
 version: 1.0.1-SNAPSHOT
 main: de.dergamer09.Main
-api: 1.1.0
+api: 1.0.0
 author: DerGamer09
 
 commands:


### PR DESCRIPTION
## Summary
- update `api` in plugin.yml from 1.1.0 to 1.0.0

## Testing
- `./gradlew build` *(fails: HTTP 403 due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6861bd7524a8832e93ff3236c7126a18